### PR TITLE
Nested attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.DS_Store

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,16 @@
+{
+  "name": "reveal-embed-video",
+  "version": "1.0",
+  "homepage": "https://github.com/pragdave/reveal-embed-video",
+  "authors": [
+    "Dave Thomas"
+  ],
+  "description": "Embed local video in a reveal.js presentation",
+  "keywords": [
+    "reveal",
+    "video"
+  ],
+  "ignore": [
+    "**/.*"
+  ]
+}

--- a/reveal-embed-video.css
+++ b/reveal-embed-video.css
@@ -1,0 +1,55 @@
+video.live-video {
+  position: fixed;
+  z-index: 12;
+  left: 5%;
+  top:  5%;
+  width: 25%;
+  height: auto;
+  transition: width ease 1s, height ease 1s;
+  border: 3px solid #888 !important;
+  box-shadow: 3px 3px 3px #000;
+}
+
+video.live-video.blank {
+  display: none;
+}
+
+video.live-video.big {
+  width: 90%;
+  max-height: 90%;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+video.live-video.small {
+  width: 15%;
+  max-height: 25%;
+}
+
+video.live-video.top-right {
+  right: 5%;
+  top: 5%;
+  left: auto;
+  bottom: auto;
+}
+
+video.live-video.top-left {
+  left: 5%;
+  top:  5%;
+  right: auto;
+  bottom: auto;
+}
+
+video.live-video.bottom-right {
+  right:  5%;
+  bottom: 5%;
+  left: auto;
+  top: auto;
+}
+
+video.live-video.bottom-left {
+  left:   5%;
+  bottom: 5%;
+  right: auto;
+  top: auto;
+}


### PR DESCRIPTION
Adds default CSS styles to the package. They are loaded dynamically.
If the slide does not have a data-video attribute it is fetched from its ancestors. ("blank" can be used to disable it on an descendant.)

I added some conditions to the `startVideo()` function to fix some flickering on the slide toggle.